### PR TITLE
Clark: Move SpriteFrames changes to clark folder

### DIFF
--- a/scenes/quests/story_quests/clark/0_clark_intro/clark_intro.tscn
+++ b/scenes/quests/story_quests/clark/0_clark_intro/clark_intro.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_70cas"]
 [ext_resource type="Texture2D" uid="uid://h3osdb6ucbi3" path="res://intro image.jpg" id="1_cs3gf"]
-[ext_resource type="SpriteFrames" uid="uid://bnjxi6eayjssy" path="res://scenes/quests/story_quests/template/template_player_components/template_player.tres" id="3_hyyia"]
+[ext_resource type="SpriteFrames" uid="uid://bnjxi6eayjssy" path="res://scenes/quests/story_quests/clark/clark_player_components/clark_player_2.tres" id="3_hyyia"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="4_gn7sj"]
 [ext_resource type="Resource" uid="uid://4ufxumuwp01q" path="res://scenes/quests/story_quests/clark/0_clark_intro/clark_intronew.dialogue" id="5_70cas"]
 

--- a/scenes/quests/story_quests/clark/2_clark_combat/clark_combat.tscn
+++ b/scenes/quests/story_quests/clark/2_clark_combat/clark_combat.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=12 format=4 uid="uid://c4ww8g4jusqpd"]
+[gd_scene load_steps=14 format=4 uid="uid://c4ww8g4jusqpd"]
 
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="1_fxm8o"]
 [ext_resource type="Resource" uid="uid://3vrn5jdxov37" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_combat.dialogue" id="2_3t3ix"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="3_iw5rn"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="4_bivjm"]
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn" id="5_ocnlb"]
+[ext_resource type="SpriteFrames" uid="uid://dl17ybh6v7qfy" path="res://scenes/quests/story_quests/clark/2_clark_combat/template_combat_components/clark_throwing_enemy.tres" id="6_5d3td"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="6_j5fbu"]
+[ext_resource type="SpriteFrames" uid="uid://sa034wogbraj" path="res://scenes/quests/story_quests/clark/2_clark_combat/template_combat_components/clark_projectile_spriteframes.tres" id="7_nkhfb"]
 [ext_resource type="SpriteFrames" uid="uid://c50725q5ey5j5" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_target_spriteframes.tres" id="7_td2g7"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_xcofd"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_sv066"]
@@ -53,6 +55,8 @@ scale = Vector2(1.56329, 2.32)
 [node name="ThrowingNPC" parent="OnTheGround" instance=ExtResource("5_ocnlb")]
 position = Vector2(857, 300)
 scale = Vector2(1.68, 1.84)
+sprite_frames = ExtResource("6_5d3td")
+projectile_sprite_frames = ExtResource("7_nkhfb")
 
 [node name="Target" parent="OnTheGround" instance=ExtResource("6_j5fbu")]
 position = Vector2(502, 164)

--- a/scenes/quests/story_quests/clark/2_clark_combat/template_combat_components/clark_projectile_spriteframes.tres
+++ b/scenes/quests/story_quests/clark/2_clark_combat/template_combat_components/clark_projectile_spriteframes.tres
@@ -1,16 +1,16 @@
 [gd_resource type="SpriteFrames" load_steps=3 format=3 uid="uid://sa034wogbraj"]
 
-[ext_resource type="Texture2D" uid="uid://cagyo41xspko" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_projectile.png" id="1_qj6l0"]
+[ext_resource type="Texture2D" uid="uid://cf12eofwe3vpk" path="res://scenes/New Piskel.png" id="1_a6pw8"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_a6ony"]
-atlas = ExtResource("1_qj6l0")
-region = Rect2(0, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_2sgco"]
+atlas = ExtResource("1_a6pw8")
+region = Rect2(0, 0, 32, 32)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_a6ony")
+"texture": SubResource("AtlasTexture_2sgco")
 }],
 "loop": true,
 "name": &"default",

--- a/scenes/quests/story_quests/clark/2_clark_combat/template_combat_components/clark_throwing_enemy.tres
+++ b/scenes/quests/story_quests/clark/2_clark_combat/template_combat_components/clark_throwing_enemy.tres
@@ -1,121 +1,85 @@
-[gd_resource type="SpriteFrames" load_steps=25 format=3 uid="uid://dl17ybh6v7qfy"]
+[gd_resource type="SpriteFrames" load_steps=18 format=3 uid="uid://dl17ybh6v7qfy"]
 
-[ext_resource type="Texture2D" uid="uid://cd2ivq0ll3lt0" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_attack.png" id="1_6l2sj"]
-[ext_resource type="Texture2D" uid="uid://cb3lim37pj3by" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_defeated.png" id="2_5kvk6"]
-[ext_resource type="Texture2D" uid="uid://dlyqia7fiovw1" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_idle.png" id="3_ccl0m"]
-[ext_resource type="Texture2D" uid="uid://ddsr4nuoutyif" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_walk.png" id="4_ygmgm"]
+[ext_resource type="Texture2D" uid="uid://blebi1oenq8f2" path="res://scenes/New Piskel-3.png" id="1_u6cdp"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_mind4"]
-atlas = ExtResource("1_6l2sj")
-region = Rect2(384, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_onxd6"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_k4l6k"]
-atlas = ExtResource("1_6l2sj")
-region = Rect2(576, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_ht7qv"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_rhel8"]
-atlas = ExtResource("1_6l2sj")
-region = Rect2(768, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_1tw8b"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_berh2"]
-atlas = ExtResource("1_6l2sj")
-region = Rect2(960, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_vsy0o"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_2682x"]
-atlas = ExtResource("1_6l2sj")
-region = Rect2(0, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_clhtx"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_l11hj"]
-atlas = ExtResource("1_6l2sj")
-region = Rect2(192, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_0rs15"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_websu"]
-atlas = ExtResource("2_5kvk6")
-region = Rect2(0, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_8ghv6"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_frle3"]
-atlas = ExtResource("2_5kvk6")
-region = Rect2(192, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_jn6wn"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_int2m"]
-atlas = ExtResource("2_5kvk6")
-region = Rect2(384, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_y6op0"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_7p5mt"]
-atlas = ExtResource("2_5kvk6")
-region = Rect2(576, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_j1n1u"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_wocwu"]
-atlas = ExtResource("3_ccl0m")
-region = Rect2(0, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_ijm1p"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_koein"]
-atlas = ExtResource("3_ccl0m")
-region = Rect2(192, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_xbvrl"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_43lix"]
-atlas = ExtResource("3_ccl0m")
-region = Rect2(384, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_jqc1x"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_468gl"]
-atlas = ExtResource("3_ccl0m")
-region = Rect2(192, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_f1iov"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 0, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_wt8op"]
-atlas = ExtResource("4_ygmgm")
-region = Rect2(0, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_nwe3m"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(0, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_tu8xg"]
-atlas = ExtResource("4_ygmgm")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_rddrd"]
-atlas = ExtResource("4_ygmgm")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_72inp"]
-atlas = ExtResource("4_ygmgm")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_1xyr8"]
-atlas = ExtResource("4_ygmgm")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wmnhy"]
-atlas = ExtResource("4_ygmgm")
-region = Rect2(384, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_wd60s"]
+atlas = ExtResource("1_u6cdp")
+region = Rect2(64, 64, 64, 64)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_mind4")
+"texture": SubResource("AtlasTexture_onxd6")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_k4l6k")
+"texture": SubResource("AtlasTexture_ht7qv")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_rhel8")
+"texture": SubResource("AtlasTexture_1tw8b")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_berh2")
-}],
-"loop": false,
-"name": &"attack",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_2682x")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_l11hj")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_2682x")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_l11hj")
+"texture": SubResource("AtlasTexture_vsy0o")
 }],
 "loop": false,
 "name": &"attack anticipation",
@@ -123,16 +87,16 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_websu")
+"texture": SubResource("AtlasTexture_clhtx")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_frle3")
+"texture": SubResource("AtlasTexture_0rs15")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_int2m")
+"texture": SubResource("AtlasTexture_8ghv6")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_7p5mt")
+"texture": SubResource("AtlasTexture_jn6wn")
 }],
 "loop": false,
 "name": &"defeated",
@@ -140,28 +104,16 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_wocwu")
+"texture": SubResource("AtlasTexture_y6op0")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_wocwu")
+"texture": SubResource("AtlasTexture_j1n1u")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_wocwu")
+"texture": SubResource("AtlasTexture_ijm1p")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_koein")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_43lix")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_43lix")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_43lix")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_468gl")
+"texture": SubResource("AtlasTexture_xbvrl")
 }],
 "loop": true,
 "name": &"idle",
@@ -169,22 +121,16 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_wt8op")
+"texture": SubResource("AtlasTexture_jqc1x")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_tu8xg")
+"texture": SubResource("AtlasTexture_f1iov")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_rddrd")
+"texture": SubResource("AtlasTexture_nwe3m")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_72inp")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_1xyr8")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_wmnhy")
+"texture": SubResource("AtlasTexture_wd60s")
 }],
 "loop": true,
 "name": &"walk",

--- a/scenes/quests/story_quests/clark/clark_player_components/clark_player.tres
+++ b/scenes/quests/story_quests/clark/clark_player_components/clark_player.tres
@@ -2,7 +2,7 @@
 
 [ext_resource type="Texture2D" uid="uid://c0itxt8w3yml0" path="res://scenes/quests/story_quests/template/template_player_components/template_player_attack_01.png" id="1_wj51i"]
 [ext_resource type="Texture2D" uid="uid://covbt3em3ppm1" path="res://scenes/quests/story_quests/template/template_player_components/template_player_attack_02.png" id="2_fsdns"]
-[ext_resource type="Texture2D" uid="uid://bu3iwg7bfdn8j" path="res://clark_player_dead_turtle.png" id="3_cjkke"]
+[ext_resource type="Texture2D" uid="uid://dwjtxyn7fjc5p" path="res://scenes/clark_player_dead_turtle.png" id="3_cjkke"]
 [ext_resource type="Texture2D" uid="uid://cr0aho7p8o4k3" path="res://scenes/quests/story_quests/clark/clark_player_components/clark_player_walk_turtle.png" id="5_1x0xi"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_yg72c"]

--- a/scenes/quests/story_quests/clark/clark_player_components/clark_player_2.tres
+++ b/scenes/quests/story_quests/clark/clark_player_components/clark_player_2.tres
@@ -1,0 +1,216 @@
+[gd_resource type="SpriteFrames" load_steps=30 format=3 uid="uid://bnjxi6eayjssy"]
+
+[ext_resource type="Texture2D" uid="uid://drsfkwvrsagi5" path="res://scenes/clark_player_walk_turtle.png" id="1_f6cqg"]
+[ext_resource type="Texture2D" uid="uid://dwjtxyn7fjc5p" path="res://scenes/clark_player_dead_turtle.png" id="2_5ebfn"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5ebfn"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_m5whc"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_bi3qj"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_qxir4"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_cu6lk"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(768, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_icahe"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(960, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_gjf71"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(1152, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_eyp3i"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nw7ra"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3yb8r"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_tix8p"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_bxyd7"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(768, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_yvbx4"]
+atlas = ExtResource("2_5ebfn")
+region = Rect2(64, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ksvv2"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_c63s3"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rlbwo"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_oalp1"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_l3u6n"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(768, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_w27rc"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(960, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_6wpxs"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(1152, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rpjoy"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fnkh0"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kaewf"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3iva5"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_acqxw"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(768, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_bubfe"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(960, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_xoar2"]
+atlas = ExtResource("1_f6cqg")
+region = Rect2(1152, 0, 192, 192)
+
+[resource]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5ebfn")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_m5whc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_bi3qj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_qxir4")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_icahe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_gjf71")
+}],
+"loop": true,
+"name": &"attack_02",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_eyp3i")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nw7ra")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3yb8r")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_tix8p")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_bxyd7")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yvbx4")
+}],
+"loop": false,
+"name": &"defeated",
+"speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ksvv2")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_c63s3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_rlbwo")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_oalp1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l3u6n")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_w27rc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_6wpxs")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_rpjoy")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fnkh0")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kaewf")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3iva5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_acqxw")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_bubfe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_xoar2")
+}],
+"loop": true,
+"name": &"walk",
+"speed": 10.0
+}]

--- a/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_projectile_spriteframes.tres
+++ b/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_projectile_spriteframes.tres
@@ -1,16 +1,16 @@
 [gd_resource type="SpriteFrames" load_steps=3 format=3 uid="uid://b00dcfe4dtvkh"]
 
-[ext_resource type="Texture2D" uid="uid://cf12eofwe3vpk" path="res://scenes/New Piskel.png" id="1_a6pw8"]
+[ext_resource type="Texture2D" uid="uid://cagyo41xspko" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_projectile.png" id="1_pusms"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_2sgco"]
-atlas = ExtResource("1_a6pw8")
-region = Rect2(0, 0, 32, 32)
+[sub_resource type="AtlasTexture" id="AtlasTexture_a6ony"]
+atlas = ExtResource("1_pusms")
+region = Rect2(0, 0, 64, 64)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_2sgco")
+"texture": SubResource("AtlasTexture_a6ony")
 }],
 "loop": true,
 "name": &"default",

--- a/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy.tres
+++ b/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy.tres
@@ -1,85 +1,121 @@
-[gd_resource type="SpriteFrames" load_steps=18 format=3 uid="uid://deosvk5k4su5f"]
+[gd_resource type="SpriteFrames" load_steps=25 format=3 uid="uid://deosvk5k4su5f"]
 
-[ext_resource type="Texture2D" uid="uid://blebi1oenq8f2" path="res://scenes/New Piskel-3.png" id="1_u6cdp"]
+[ext_resource type="Texture2D" uid="uid://cd2ivq0ll3lt0" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_attack.png" id="1_53o2g"]
+[ext_resource type="Texture2D" uid="uid://cb3lim37pj3by" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_defeated.png" id="2_2ntg4"]
+[ext_resource type="Texture2D" uid="uid://dlyqia7fiovw1" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_idle.png" id="3_mind4"]
+[ext_resource type="Texture2D" uid="uid://ddsr4nuoutyif" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy_walk.png" id="4_k4l6k"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_onxd6"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_mind4"]
+atlas = ExtResource("1_53o2g")
+region = Rect2(384, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ht7qv"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_k4l6k"]
+atlas = ExtResource("1_53o2g")
+region = Rect2(576, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_1tw8b"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_rhel8"]
+atlas = ExtResource("1_53o2g")
+region = Rect2(768, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_vsy0o"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_berh2"]
+atlas = ExtResource("1_53o2g")
+region = Rect2(960, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_clhtx"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_2682x"]
+atlas = ExtResource("1_53o2g")
+region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_0rs15"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_l11hj"]
+atlas = ExtResource("1_53o2g")
+region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_8ghv6"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_websu"]
+atlas = ExtResource("2_2ntg4")
+region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_jn6wn"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_frle3"]
+atlas = ExtResource("2_2ntg4")
+region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_y6op0"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_int2m"]
+atlas = ExtResource("2_2ntg4")
+region = Rect2(384, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_j1n1u"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_7p5mt"]
+atlas = ExtResource("2_2ntg4")
+region = Rect2(576, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ijm1p"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_wocwu"]
+atlas = ExtResource("3_mind4")
+region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_xbvrl"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_koein"]
+atlas = ExtResource("3_mind4")
+region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_jqc1x"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_43lix"]
+atlas = ExtResource("3_mind4")
+region = Rect2(384, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_f1iov"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 0, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_468gl"]
+atlas = ExtResource("3_mind4")
+region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_nwe3m"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(0, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_wt8op"]
+atlas = ExtResource("4_k4l6k")
+region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_wd60s"]
-atlas = ExtResource("1_u6cdp")
-region = Rect2(64, 64, 64, 64)
+[sub_resource type="AtlasTexture" id="AtlasTexture_tu8xg"]
+atlas = ExtResource("4_k4l6k")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rddrd"]
+atlas = ExtResource("4_k4l6k")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_72inp"]
+atlas = ExtResource("4_k4l6k")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1xyr8"]
+atlas = ExtResource("4_k4l6k")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wmnhy"]
+atlas = ExtResource("4_k4l6k")
+region = Rect2(384, 0, 192, 192)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_onxd6")
+"texture": SubResource("AtlasTexture_mind4")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ht7qv")
+"texture": SubResource("AtlasTexture_k4l6k")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_1tw8b")
+"texture": SubResource("AtlasTexture_rhel8")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_vsy0o")
+"texture": SubResource("AtlasTexture_berh2")
+}],
+"loop": false,
+"name": &"attack",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_2682x")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l11hj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_2682x")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l11hj")
 }],
 "loop": false,
 "name": &"attack anticipation",
@@ -87,16 +123,16 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_clhtx")
+"texture": SubResource("AtlasTexture_websu")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_0rs15")
+"texture": SubResource("AtlasTexture_frle3")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_8ghv6")
+"texture": SubResource("AtlasTexture_int2m")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_jn6wn")
+"texture": SubResource("AtlasTexture_7p5mt")
 }],
 "loop": false,
 "name": &"defeated",
@@ -104,16 +140,28 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_y6op0")
+"texture": SubResource("AtlasTexture_wocwu")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_j1n1u")
+"texture": SubResource("AtlasTexture_wocwu")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ijm1p")
+"texture": SubResource("AtlasTexture_wocwu")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_xbvrl")
+"texture": SubResource("AtlasTexture_koein")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_43lix")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_43lix")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_43lix")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_468gl")
 }],
 "loop": true,
 "name": &"idle",
@@ -121,16 +169,22 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_jqc1x")
+"texture": SubResource("AtlasTexture_wt8op")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_f1iov")
+"texture": SubResource("AtlasTexture_tu8xg")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_nwe3m")
+"texture": SubResource("AtlasTexture_rddrd")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_wd60s")
+"texture": SubResource("AtlasTexture_72inp")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1xyr8")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_wmnhy")
 }],
 "loop": true,
 "name": &"walk",

--- a/scenes/quests/story_quests/template/template_player_components/template_player.tres
+++ b/scenes/quests/story_quests/template/template_player_components/template_player.tres
@@ -1,145 +1,106 @@
-[gd_resource type="SpriteFrames" load_steps=30 format=3 uid="uid://bnjxi6eayjssy"]
+[gd_resource type="SpriteFrames" load_steps=24 format=3 uid="uid://vwf8e1v8brdp"]
 
-[ext_resource type="Texture2D" uid="uid://drsfkwvrsagi5" path="res://scenes/clark_player_walk_turtle.png" id="1_f6cqg"]
-[ext_resource type="Texture2D" uid="uid://dwjtxyn7fjc5p" path="res://scenes/clark_player_dead_turtle.png" id="2_5ebfn"]
+[ext_resource type="Texture2D" uid="uid://c0itxt8w3yml0" path="res://scenes/quests/story_quests/template/template_player_components/template_player_attack_01.png" id="1_m5whc"]
+[ext_resource type="Texture2D" uid="uid://b0kexdddbmi7n" path="res://scenes/quests/story_quests/template/template_player_components/template_player_idle.png" id="2_bi3qj"]
+[ext_resource type="Texture2D" uid="uid://covbt3em3ppm1" path="res://scenes/quests/story_quests/template/template_player_components/template_player_attack_02.png" id="2_cu6lk"]
+[ext_resource type="Texture2D" uid="uid://dly3ikrx05f0x" path="res://scenes/quests/story_quests/template/template_player_components/template_player_defeated.png" id="2_qxir4"]
+[ext_resource type="Texture2D" uid="uid://bnb6fdjs7xeaa" path="res://scenes/quests/story_quests/template/template_player_components/template_player_walk.png" id="3_qxir4"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_5ebfn"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_yg72c"]
+atlas = ExtResource("1_m5whc")
 region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_m5whc"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_ydd7j"]
+atlas = ExtResource("1_m5whc")
 region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_bi3qj"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_f8lfs"]
+atlas = ExtResource("1_m5whc")
 region = Rect2(384, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_qxir4"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_scyt1"]
+atlas = ExtResource("1_m5whc")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_gjf71"]
+atlas = ExtResource("2_cu6lk")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_eyp3i"]
+atlas = ExtResource("2_cu6lk")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nw7ra"]
+atlas = ExtResource("2_cu6lk")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3yb8r"]
+atlas = ExtResource("2_cu6lk")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_cu6lk"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(768, 0, 192, 192)
+atlas = ExtResource("2_qxir4")
+region = Rect2(0, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_icahe"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(960, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_gjf71"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(1152, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_eyp3i"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_nw7ra"]
-atlas = ExtResource("1_f6cqg")
+atlas = ExtResource("2_qxir4")
 region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_3yb8r"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_tix8p"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(576, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_bxyd7"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(768, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_yvbx4"]
-atlas = ExtResource("2_5ebfn")
-region = Rect2(64, 64, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ksvv2"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_gwwl8"]
+atlas = ExtResource("2_bi3qj")
 region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_c63s3"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_i6uyh"]
+atlas = ExtResource("2_bi3qj")
 region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_rlbwo"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_0myta"]
+atlas = ExtResource("2_bi3qj")
 region = Rect2(384, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_oalp1"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(576, 0, 192, 192)
+[sub_resource type="AtlasTexture" id="AtlasTexture_rbvnd"]
+atlas = ExtResource("2_bi3qj")
+region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_l3u6n"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(768, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_w27rc"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(960, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6wpxs"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(1152, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_rpjoy"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_l1iol"]
+atlas = ExtResource("2_bi3qj")
 region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_fnkh0"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_28wor"]
+atlas = ExtResource("3_qxir4")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7nl6p"]
+atlas = ExtResource("3_qxir4")
 region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_kaewf"]
-atlas = ExtResource("1_f6cqg")
+[sub_resource type="AtlasTexture" id="AtlasTexture_ctslx"]
+atlas = ExtResource("3_qxir4")
 region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_3iva5"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(576, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_acqxw"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(768, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_bubfe"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(960, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_xoar2"]
-atlas = ExtResource("1_f6cqg")
-region = Rect2(1152, 0, 192, 192)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_5ebfn")
+"texture": SubResource("AtlasTexture_yg72c")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_m5whc")
+"texture": SubResource("AtlasTexture_ydd7j")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_bi3qj")
+"texture": SubResource("AtlasTexture_f8lfs")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_qxir4")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_cu6lk")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_icahe")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_gjf71")
+"texture": SubResource("AtlasTexture_scyt1")
 }],
 "loop": true,
-"name": &"attack_02",
+"name": &"attack_01",
 "speed": 10.0
 }, {
 "frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_gjf71")
+}, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_eyp3i")
 }, {
@@ -148,41 +109,79 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_3yb8r")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_tix8p")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_bxyd7")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_yvbx4")
 }],
-"loop": false,
+"loop": true,
+"name": &"attack_02",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_icahe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_icahe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_icahe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_icahe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_icahe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cu6lk")
+}],
+"loop": true,
 "name": &"defeated",
 "speed": 5.0
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ksvv2")
+"texture": SubResource("AtlasTexture_gwwl8")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_c63s3")
+"texture": SubResource("AtlasTexture_gwwl8")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_rlbwo")
+"texture": SubResource("AtlasTexture_gwwl8")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_oalp1")
+"texture": SubResource("AtlasTexture_i6uyh")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_l3u6n")
+"texture": SubResource("AtlasTexture_0myta")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_w27rc")
+"texture": SubResource("AtlasTexture_0myta")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6wpxs")
+"texture": SubResource("AtlasTexture_0myta")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_rbvnd")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l1iol")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l1iol")
 }],
 "loop": true,
 "name": &"idle",
@@ -190,25 +189,22 @@ animations = [{
 }, {
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_rpjoy")
+"texture": SubResource("AtlasTexture_28wor")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_fnkh0")
+"texture": SubResource("AtlasTexture_7nl6p")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_kaewf")
+"texture": SubResource("AtlasTexture_ctslx")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_3iva5")
+"texture": SubResource("AtlasTexture_28wor")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_acqxw")
+"texture": SubResource("AtlasTexture_7nl6p")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_bubfe")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_xoar2")
+"texture": SubResource("AtlasTexture_ctslx")
 }],
 "loop": true,
 "name": &"walk",


### PR DESCRIPTION
Previously, the player, enemy, and projectile SpriteFrames in the template had been edited. The UIDs had also been changed, which broke scripts such as player.gd which hardcode those UIDs.

To fix this:

- Move the Clark-specific SpriteFrames resources to the story_quests/clark folder
- Restore the original template files in story_quests/template
- Update the Clark scenes to refer to the Clark versions rather than the template versions
- Fix an incorrect path to the dead turtle asset